### PR TITLE
Fix URL validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-forms",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/rules/url.js
+++ b/src/rules/url.js
@@ -1,4 +1,4 @@
 export function url(val, args) {
-  const regex = (/(https?|ftp|git|svn):\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i);
-  return regex.test(url);
+  const regex = /(https?|ftp|git|svn):\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i;
+  return regex.test(val);
 }

--- a/tests/form.spec.js
+++ b/tests/form.spec.js
@@ -1,5 +1,24 @@
-describe('svelte-forms', () => {
-  test('Asserting true', () => {
-    expect(true).toBe(true);
+import { url as validateUrl } from "../src/rules/url";
+
+describe("svelte-forms", () => {
+  describe("validators", () => {
+    describe("url", () => {
+      it("passes well-formed URLs", () => {
+        const goodUrls = [
+          "http://a.b-c.de",
+          "http://code.google.com/events/#&product=browser",
+          "http://userid@example.com/",
+        ];
+        goodUrls.forEach(url => {
+          expect(validateUrl(url)).toEqual(true);
+        });
+      });
+      it("fails malformed URLs", () => {
+        const badUrls = ["just_text", "http://", "//a", ":// should fail"];
+        badUrls.forEach(url => {
+          expect(validateUrl(url)).toEqual(false);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
URL validator function is sending `url` to its test regex, but `url` is not defined.

Fix function and add tests.