### PR TITLE
Fix #8; 1 1/2 new config-options

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+	"useTabs": false,
+	"jsxSingleQuote": true,
+	"singleQuote": true,
+	"semi": true,
+	"trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ or
 
 `yarn add -D svelte-forms`
 
+## Update notes
+
+As of version 1.1.0, the [field validation objects](#fieldValidationObject) are no longer directly located inside of the [form validation object](#formValidationObject) but rather in a sub-property of it (`fields`).
+
 ## How to use
 
 ### Basic

--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,6 @@ export function bindClass(
 ) {
   const key = name || node.getAttribute('name');
 
-  console.debug({ node, form, name, key });
-
   const unsubscribe = form.subscribe((context) => {
     if (!context.fields.hasOwnProperty(key)) {
       return;

--- a/src/index.js
+++ b/src/index.js
@@ -134,11 +134,9 @@ export function form(fn, config = {}) {
   );
 
   if (config.validateOnChange) {
-    setTimeout(() => {
-      afterUpdate(() =>
-        walkThroughFields(fn, storeValue, initialFieldsData, config)
-      );
-    }, 0);
+    afterUpdate(() =>
+      walkThroughFields(fn, storeValue, initialFieldsData, config)
+    );
   }
 
   if (config.initCheck) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,28 +11,27 @@ function isPromise(obj) {
   return !!obj.then;
 }
 
-function validate(value, { field, validator, observable, enabled }) {
+function validate(fieldName, value, validator, observable, enabled = true) {
   let valid = true;
   let pending = false;
   let rule;
 
   if (enabled === false) {
-    return [valid, pending, rule];
-  }
-  else if (typeof validator === 'function') {
+    return [valid, rule, pending];
+  } else if (typeof validator === 'function') {
     const resp = validator.call(null, value);
 
     if (isPromise(resp)) {
       pending = true;
       resp.then(({ name, valid }) => {
-        observable.update(n => {
-          n[field] = n[field] || { errors: [] };
+        observable.update((n) => {
+          n[fieldName] = n[fieldName] || { errors: [] };
 
-          n[field].pending = false;
-          n[field].valid = valid;
+          n[fieldName].pending = false;
+          n[fieldName].valid = valid;
 
           if (!valid) {
-            n[field].errors.push(rule);
+            n[fieldName].errors.push(name);
           }
 
           return n;
@@ -51,33 +50,42 @@ function validate(value, { field, validator, observable, enabled }) {
   return [valid, rule, pending];
 }
 
-function field(name, config, observable, { stopAtFirstError }) {
-    const { value, validators = [], enabled = true } = config;
-    let valid = true;
-    let pending = false;
-    let errors = [];
+function validateField(data, observable, { stopAtFirstFieldError }) {
+  const { name, value, validators = [], enabled = true } = data;
 
-    if (enabled) {
-      for (let i = 0; i < validators.length; i++) {
-        const [isValid, rule, isPending] = validate(value, { field: name, validator: validators[i], observable });
-  
-        if (!pending && isPending) {
-          pending = true;
-        }
-        
-        if (!isValid) {
-          valid = false;
-          errors = [...errors, rule];
-  
-          if (stopAtFirstError) break;
-        }
+  let valid = true;
+  let pending = false;
+  let errors = [];
+
+  if (enabled) {
+    validators.some((validator) => {
+      const [isValid, rule, isPending] = validate(
+        name,
+        value,
+        validator,
+        observable
+      );
+
+      if (!pending && isPending) {
+        pending = true;
       }
-    }
 
-    return { valid, errors, pending };
+      if (!isValid) {
+        valid = false;
+        errors = [...errors, rule];
+
+        return stopAtFirstFieldError;
+      }
+    });
+  }
+
+  return { data, valid, errors, pending };
 }
 
-export function bindClass(node, { form, name, valid = 'valid', invalid = 'invalid' }) {
+export function bindClass(
+  node,
+  { form, name, valid = 'valid', invalid = 'invalid' }
+) {
   const key = name || node.getAttribute('name');
 
   const unsubscribe = form.subscribe((context) => {
@@ -86,7 +94,7 @@ export function bindClass(node, { form, name, valid = 'valid', invalid = 'invali
     } else {
       node.classList.remove(valid);
     }
-  
+
     if (context.dirty && context[key] && !context[key].valid) {
       node.classList.add(invalid);
     } else {
@@ -96,68 +104,110 @@ export function bindClass(node, { form, name, valid = 'valid', invalid = 'invali
 
   return {
     destroy: unsubscribe
-  }
-}
-
-export function form(fn, config = {}) {
-  const storeValue = writable({ oldValues: {}, dirty: false  });
-  const { subscribe, set, update } = storeValue;
-  config = Object.assign({ initCheck: true, validateOnChange: true, stopAtFirstError: true}, config);
-  
-  if (config.validateOnChange) {
-    afterUpdate(() => walkThroughFields(fn, storeValue, config));
-  }
-
-
-  if (config.initCheck) {
-    walkThroughFields(fn, storeValue, config);
-  }
-
-  return {
-    subscribe, set, update,
-
-    validate() {
-      walkThroughFields(fn, storeValue, config);  
-    }
   };
 }
 
-function walkThroughFields(fn, observable, config) {
+export function form(fn, config = {}) {
   const fields = fn.call();
-  const returnedObject = { oldValues: {}, dirty: false };
+  const initialFieldsData = Object.fromEntries(
+    Object.keys(fields).map((key) => [
+      key,
+      { name: fields[key].name, value: fields[key].value }
+    ])
+  );
+
+  console.debug({ initialFieldsData });
+
+  const storeValue = writable({
+    fields: {},
+    oldFields: {},
+    dirty: false,
+    valid: true,
+  });
+  const { subscribe, set, update } = storeValue;
+  config = Object.assign(
+    {
+      initCheck: true,
+      validateOnChange: true,
+      stopAtFirstError: false,
+      stopAtFirstFieldError: true
+    },
+    config
+  );
+
+  if (config.validateOnChange) {
+    setTimeout(() => {
+      afterUpdate(() =>
+        walkThroughFields(fn, storeValue, initialFieldsData, config)
+      );
+    }, 0);
+  }
+
+  if (config.initCheck) {
+    walkThroughFields(fn, storeValue, initialFieldsData, config);
+  }
+
+  return {
+    subscribe,
+    set,
+    update,
+
+    validate() {
+      walkThroughFields(fn, storeValue, initialFieldsData, config);
+    },
+  };
+}
+
+function walkThroughFields(fn, observable, initialFieldsData, config) {
+  const fields = fn.call();
   const context = get(observable);
+  const returnedObject = {
+    fields: {},
+    oldFields: {},
+    dirty: false,
+  };
 
-  returnedObject.dirty = context.dirty;
+  Object.keys(fields).some((key) => {
+    const field = fields[key];
+    const oldField = context.fields[key] || {
+      data: {},
+      errors: [],
+      pending: false,
+      valid: true,
+      enabled: true
+    };
+    const initialFieldData = initialFieldsData[key];
 
-  Object.keys(fields).forEach(key => {
-    const value = getValue(fields[key]);
-    const enabled = fields[key].enabled;
-    const oldValue = context.oldValues[key] || { value: undefined, enabled: true };
+    const value = getValue(field);
+    const oldValue = getValue(oldField);
+    const enabled = field.enabled;
+    const oldEnabled = oldField.enabled;
 
-    if (enabled !== oldValue.enabled || value !== oldValue.value) {
-      returnedObject[key] = field(key, fields[key], observable, config);
-    }
-    else {
-      returnedObject[key] = context[key];
-        
+    if (enabled !== oldEnabled || value !== oldValue) {
+      returnedObject.fields[key] = validateField(field, observable, config);
+    } else {
+      returnedObject.fields[key] = context.fields[key];
+
       if (!enabled) {
-        returnedObject[key].valid = true;
-        returnedObject[key].errors = [];
+        returnedObject.fields[key].valid = true;
+        returnedObject.fields[key].errors = [];
       }
     }
 
-    returnedObject.oldValues[key] = { value, enabled };
-    
-    if (!context.dirty && oldValue.value !== undefined && value !== oldValue.value) {
+    if (value !== initialFieldData.value) {
       returnedObject.dirty = true;
+    }
+
+    returnedObject.oldFields[key] = oldField;
+
+    if (config.stopAtFirstError) {
+      return !returnedObject.fields[key].valid;
     }
   });
 
-  returnedObject.valid = !Object.keys(returnedObject).find(f => {
-    if (['oldValues', 'dirty'].includes(f)) return false;
-    return !returnedObject[f].valid;
-  });
+  returnedObject.valid = !Object.keys(returnedObject.fields).find(
+    (f) => !returnedObject.fields[f].valid
+  );
 
   observable.set(returnedObject);
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -116,8 +116,6 @@ export function form(fn, config = {}) {
     ])
   );
 
-  console.debug({ initialFieldsData });
-
   const storeValue = writable({
     fields: {},
     oldFields: {},


### PR DESCRIPTION
I have made multiple changes apart from just fixing #8. I hope that is okay, else I'll remove the other changes and make a separate PR or something.

List of all changes:

*   Move all field data in the store into the property `fields` (this is, to prevent from overriding `dirty` and `valid` on the form itself (I guess this makes it one property more "difficult" to manually access the generated things on the fields)
*   Renamed the config-option `stopAtFirstError` to `stopAtFirstFieldError` (it still has the same functionality)
*   Added a new config-option `stopAtFirstError` (which stops at the first error of all fields to be validated)
*   All fields now have the original data in a property `data` (to prevent overriding `errors`, `pending`, `valid` and `enabled`)
*   Added `initialFieldsData` which keeps all the fields with their original data when the form gets initialized (so a field with a default value that has been changed multiple times and then back to the default value will not be dirty) (not sure, if the original implementation actually did this, as, to be honest, I kinda lost myself in there :sweat\_smile:)
*   ~Wrapped the `afterUpdate`-do-`walkThroughFields` in a `setTimeout` to prevent an instant call after creating the form (I experienced this while using [SMUI](https://github.com/hperrin/svelte-material-ui), and I haven't tested yet, if this also happens with plain elements)~
*   Rename `oldValues` to `oldFields`
*   If the validator is async, push `name` to the field' errors instead of `rule` (which, I think would be `undefined`)
*   Rename the function `field` to `validateField`
*   I've changed the `for`\-loop in the `validateField`\-function and the `Object.keys(fields).forEach`\-loop in `walkThroughFields` to be a `some`\-loop instead (not entirely sure, if this might be bad, although I'd expect that Babel would automatically polyfill it)

In addition, as I renamed and moved a few things around, the docs will need an update, which I will be happy to do, once all the things are decided to be good or changed to be good.

Also, you might notice that I wasn't able to keep the code-style.