### PR TITLE
Use OWASP email REGEX + add tests

### DIFF
--- a/src/rules/email.js
+++ b/src/rules/email.js
@@ -1,5 +1,6 @@
 export function email(val, args) {
-  const regex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  // Email regex from Open Web Application Security Project (OWASP) : https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+  const regex = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,7}$/
 
   return val && regex.test(val);
 }

--- a/tests/form.spec.js
+++ b/tests/form.spec.js
@@ -1,7 +1,9 @@
 import { url as validateUrl } from "../src/rules/url";
+import { email as validateEmail } from "../src/rules/email";
 
 describe("svelte-forms", () => {
   describe("validators", () => {
+
     describe("url", () => {
       it("passes well-formed URLs", () => {
         const goodUrls = [
@@ -13,6 +15,7 @@ describe("svelte-forms", () => {
           expect(validateUrl(url)).toEqual(true);
         });
       });
+
       it("fails malformed URLs", () => {
         const badUrls = ["just_text", "http://", "//a", ":// should fail"];
         badUrls.forEach(url => {
@@ -21,4 +24,24 @@ describe("svelte-forms", () => {
       });
     });
   });
+
+  describe("email", () => {
+
+    it("passes well-formed emails", () => {
+      const goodEmails = ["email@email.com", "my.email@example.fr"];
+      goodEmails.forEach(email => {
+        expect(validateEmail(email)).toEqual(true);
+      });
+    });
+
+    it("fails malformed emails", () => {
+      const badEmails = ["just_text", ".email@email", "email@email@email", "email.@email", "email@email", "email@", "@gmail.com", 12];
+      badEmails.forEach(email => {
+        expect(validateEmail(email)).toEqual(false);
+      });
+    });
+
+  });
+
+
 });


### PR DESCRIPTION
OWASP regexes are more secure (in order to avoid Regular expression Denial of Service - aka ReDOS) :
https://owasp.org/www-community/OWASP_Validation_Regex_Repository

I have added some email tests in the same time 😉 

Thank you :)