### PR TITLE
Add 'dirty' class for each field

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,16 @@ function manualValidation() {
 }
 ```
 
-### `bindClass({ form: StoreObservable, name: string, valid: string = 'valid', invalid: string = 'invalid' })`
+### `bindClass({ form: StoreObservable, name: string, valid: string = 'valid', invalid: string = 'invalid', dirty: string = 'dirty' })`
 
 > ```html
 > <input type="text" name="username" use:bindClass={{ form: loginForm }} />
 > <input type="text" use:bindClass={{ form: loginForm, name: "username" }} />
 > ```
 
-Automatically adds `valid` or `invalid` (default value) classes to the input **IF**
-the form is dirty **AND** every rule is matched.
+Automatically adds `valid` or `invalid` and `dirty` (default value) classes to the input:
+* Adds `valid` or `invalid` **IF** the form is dirty **AND** every rule is matched.
+* Adds `dirty` if field is dirty.
 
 If `bindClass` is used on a DOM node that has an attribute `name`, it will check for this field.
 Otherwise you can set the field by setting the `name` parameter.

--- a/src/index.js
+++ b/src/index.js
@@ -86,8 +86,7 @@ function validateField(data, observable, { stopAtFirstFieldError }) {
 }
 
 export function bindClass(
-  node,
-  { form, name, valid = 'valid', invalid = 'invalid' }
+  node, { form, name = undefined, valid = 'valid', invalid = 'invalid', dirty = 'dirty' }
 ) {
   const key = name || node.getAttribute('name');
 
@@ -103,6 +102,11 @@ export function bindClass(
     } else {
       node.classList.remove(valid);
       node.classList.add(invalid);
+    }
+    if (field.dirty) {
+      node.classList.add(dirty);
+    } else {
+      node.classList.remove(dirty);
     }
   });
 
@@ -177,7 +181,8 @@ function walkThroughFields(fn, observable, initialFieldsData, config) {
       errors: [],
       pending: false,
       valid: true,
-      enabled: true
+      enabled: true,
+      dirty: false
     };
     const initialFieldData = initialFieldsData[key];
 
@@ -200,6 +205,7 @@ function walkThroughFields(fn, observable, initialFieldsData, config) {
     if (value !== initialFieldData.value) {
       returnedObject.dirty = true;
     }
+    returnedObject.fields[key].dirty = value !== initialFieldData.value;
 
     returnedObject.oldFields[key] = Object.assign({}, oldField);
 


### PR DESCRIPTION
Hello,

As I commented in https://github.com/chainlist/svelte-forms/issues/17#issuecomment-702811949, I need to highlight when some field in the form has changed.

I've modified the code to automatically add the 'dirty' class to fields using the `bindClass` method.

Please consider to add this change into the source code (and restore the NPM link, please ;) )

Best Regards,
Ferran
