### PR TITLE
Added support for SSR platforms like SvelteKit - no afterUpdate on SSR

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,8 @@ export function form(fn, config = {}) {
       initCheck: true,
       validateOnChange: true,
       stopAtFirstError: false,
-      stopAtFirstFieldError: true
+      stopAtFirstFieldError: true,
+      isSSR: false,
     },
     config
   );
@@ -167,7 +168,7 @@ export function form(fn, config = {}) {
   });
   const { subscribe, set, update } = storeValue;
 
-  if (config.validateOnChange) {
+  if (config.validateOnChange && !config.isSSR) {
     afterUpdate(() => {
       walkThroughFields(fn, storeValue, initialFieldsData, config);
     });


### PR DESCRIPTION
This PR solves the SvelteKit SSR error `Function called outside of component initialization`.
I have added a config option `isSSR: boolean` which will prevent running `afterUpdate(...)` if `isSSR` is `true`.

Developers who are using `svelte-forms` with `SvelteKit` can pass this config option like below :
```svelte
<script>
  ...
  import { form, bindClass } from 'svelte-forms';
  import { browser } from '$app/env';
  
  let someForm = form(() => {
    ...
  }, {
     ...
     isSSR: !browser
  })
  ...
</script>
``` 