### PR TITLE
implement `summary` method on the form

### DIFF
--- a/src/docs/3_Form.md
+++ b/src/docs/3_Form.md
@@ -22,6 +22,7 @@ In addition there is two different functions that can be called on the store:
 - `reset()` which resets all the binded `field`
 - `validate()` which launches a manual validation of all the binded `field`
 - `getField(name: string): Writable<Field<any>>` which returns a previously binded `field`. Useful when you pass your form around components.
+- `summary()` returns an object the represents the current state of all values that have been entered in the form
 
 ### hasError
 

--- a/src/docs/3_Form.md
+++ b/src/docs/3_Form.md
@@ -22,7 +22,7 @@ In addition there is two different functions that can be called on the store:
 - `reset()` which resets all the binded `field`
 - `validate()` which launches a manual validation of all the binded `field`
 - `getField(name: string): Writable<Field<any>>` which returns a previously binded `field`. Useful when you pass your form around components.
-- `summary()` returns an object the represents the current state of all values that have been entered in the form
+- `summary()` returns an object that represents the current state of all the fields that have been linked to the form
 
 ### hasError
 

--- a/src/lib/form.ts
+++ b/src/lib/form.ts
@@ -64,5 +64,14 @@ export function form(...fields: (Writable<Field<any>> | Readable<Field<any>>)[])
 		return fields.find((f) => get(f).name === name);
 	}
 
-	return { subscribe, reset, validate, getField };
+	function summary(): Record<string, any> {
+		return fields.reduce((carry, field) => {
+			const fieldContent = get(field);
+			carry[fieldContent.name] = fieldContent.value;
+
+			return carry;
+		}, {});
+	}
+
+	return { subscribe, reset, validate, getField, summary };
 }

--- a/src/tests/form.test.ts
+++ b/src/tests/form.test.ts
@@ -31,4 +31,15 @@ describe('form()', () => {
 
 		expect(() => form(name, name)).toThrowError();
 	});
+
+	it('should create a form summary', () => {
+		const firstName = field('firstName', 'John');
+		const lastName = field('lastName', 'Doe');
+		const myForm = form(firstName, lastName);
+
+		expect(myForm.summary()).toEqual({
+			firstName: 'John',
+			lastName: 'Doe'
+		});
+	});
 });


### PR DESCRIPTION
Currently it is neccessary to pick the values from any field explicitly.
It would be nice to have a convenience method that picks all the data from the form at once. This PR provides a proposal on how this could be outlined.