### PR TITLE
Fix issue #76 of unintended validation of fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # svelte-forms
 
+## 2.3.1
+
+### Patch Changes
+
+- Fix behavior when validate on change is false
+
 ## 2.3.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"validations",
 		"svelte-forms"
 	],
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build && touch build/.nojekyll",

--- a/src/lib/createFieldStore.ts
+++ b/src/lib/createFieldStore.ts
@@ -75,7 +75,7 @@ export function processField<T>(
 	if (validations) {
 		const errors = validations.filter((v) => !v.valid).map((v) => v.name);
 		const valid = !errors.length;
-		return { ...field, valid, invalid: !valid, errors, ...partialField };
+		return { ...field, valid: valid, invalid: !valid, errors, ...partialField };
 		// return { ...field, dirty: field.dirty || !!validations.length, valid, invalid: !valid, errors, ...partialField };
 	}
 
@@ -113,7 +113,7 @@ export function createFieldStore<T>(
 			let validations = await getErrors(field, validators, options.stopAtFirstError);
 			_set(processField(field, validations, { dirty: true }));
 		} else {
-			_set(processField(field, [], { dirty: true }));
+			_set(processField(field, null, { dirty: true }));
 		}
 	}
 

--- a/src/tests/field.test.ts
+++ b/src/tests/field.test.ts
@@ -1,5 +1,5 @@
 import { field } from '$lib';
-import { min, required } from '$lib/validators';
+import { min, required, email } from '$lib/validators';
 import { get } from 'svelte/store';
 
 describe('field()', () => {
@@ -114,5 +114,19 @@ describe('field()', () => {
 			const result = get(name);
 			expect(result.value).toBeNull();
 		});
+	});
+
+	it('should remain invalid on change', async () => {
+		let emailOptions = { validateOnChange: false, valid: false };
+		const emailField = field('emailField', "", [email()], emailOptions);
+
+		emailField.set(get(field('emailField', 'not an email', [email()], emailOptions)));
+		expect(get(emailField).valid).toEqual(false);
+
+		emailField.set(get(field('emailField', 'hello@email.com', [email()], emailOptions)));
+		expect(get(emailField).valid).toEqual(false);
+		
+		await emailField.validate();
+		expect(get(emailField).valid).toEqual(true);
 	});
 });


### PR DESCRIPTION
Passes null instead of [] as
validations to processField when calling set function of a
field with a Field object.

Assign the value of valid to the property valid in returned
Field object in createFieldStore.ts L. 78