### PR TITLE
docs: Fixed tiny typo in import declaration @:21

### DIFF
--- a/src/docs/4_Field.md
+++ b/src/docs/4_Field.md
@@ -18,7 +18,7 @@ function field<T>(
 You can directly use the store to set the field value programatically if you need to.
 
 ```typescript
-import { field } from 'svete-forms';
+import { field } from 'svelte-forms';
 import { get } from 'svelte/store';
 
 const name = field('name', '');


### PR DESCRIPTION
import { field } from 'svete-forms'; >> import { field } from 'svelte-forms';