### PR TITLE
Update email validator name in documenation

### DIFF
--- a/src/docs/6_Validators.md
+++ b/src/docs/6_Validators.md
@@ -25,7 +25,7 @@ const name = field('name', '', [required()]);
 ### email
 
 ```typescript
-function email() => { valid: boolean, name : 'email' };
+function email() => { valid: boolean, name : 'not_an_email' };
 ```
 
 ```typescript


### PR DESCRIPTION
docs say that the name for email validator is 'email' but according to source code, it should be 'not_an_email'