### PR TITLE
Update docs to make first example work as expected

### DIFF
--- a/src/docs/2_Examples.md
+++ b/src/docs/2_Examples.md
@@ -11,7 +11,7 @@ filename: 2_Examples.md
   import { form, field } from 'svelte-forms';
   import { required } from 'svelte-forms/validators';
 
-  const name = field('name', '', [required()]);
+  const name = field('name', '', [required()], { checkOnInit: true });
   const myForm = form(name);
 </script>
 


### PR DESCRIPTION
Fixes https://github.com/chainlist/svelte-forms/issues/95 

It's expected that a form would behave as if it has `checkOnInit: true`: empty form is invalid - false, once you add some input, it's true.  One can of course read the documentation in detail to figure out what's wrong, but it might be useful for the first example to be self-contained.

The change was proposed by grischaerbe in the issue, and it is already explained in documentation. Thoughts on adding this to documentation?