### PR TITLE
fix: incorrect TLD length in email validation

### DIFF
--- a/src/lib/validators/email.ts
+++ b/src/lib/validators/email.ts
@@ -2,7 +2,7 @@ import type { Validator } from './validator.js';
 
 export function email(): Validator {
 	return (value: any) => {
-		const regex = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,7}$/;
+		const regex = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}$/;
 		return { valid: Boolean(value) && regex.test(value), name: 'not_an_email' };
 	};
 }


### PR DESCRIPTION
The email validator has a character length restriction between 2 and 7 characters.

However, there are valid TLDs that are longer than that, e.g. .technology, .international, .photography, .university, .solutions, .foundation, etc. In [this list of all currently valid TLDs](https://data.iana.org/TLD/tlds-alpha-by-domain.txt), there are many that are longer than 7 characters; it seems that the maximum length currently in use is 24. In fact, TLDs per the ICANN spec can be up to [63 characters, according to MDN](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_domain_name).

The solution is to change the maximum length in the regex from 7 to 63.

Merging this would close #119.
